### PR TITLE
Add authentication flow and hierarchical user management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Sidebar } from './components/Layout/Sidebar';
 import { Header } from './components/Layout/Header';
 import { DashboardView } from './components/Dashboard/DashboardView';
@@ -10,20 +10,32 @@ import { TripsView } from './components/Trips/TripsView';
 import { SettingsView } from './components/Settings/SettingsView';
 import { AdminView } from './components/Admin/AdminView';
 import { FleetMapView } from './components/Map/FleetMapView';
-import { 
-  mockDevices, 
-  mockDrivers, 
-  mockVehicles, 
-  mockTrips, 
-  mockAlerts, 
-  mockGeofences 
+import { LoginView } from './components/Auth/LoginView';
+import {
+  mockDevices,
+  mockDrivers,
+  mockVehicles,
+  mockTrips,
+  mockAlerts,
+  mockGeofences,
 } from './data/mockData';
+import { mockAuthUsers } from './data/authUsers';
 import { Alert } from './types';
+import { AuthRole, AuthUser, LoginCredentials, SessionUser } from './types/auth';
+
+const viewPermissions: Record<AuthRole, string[]> = {
+  super_admin: ['dashboard', 'map', 'vehicles', 'drivers', 'geofences', 'alerts', 'trips', 'admin', 'settings'],
+  master_admin: ['dashboard', 'map', 'vehicles', 'drivers', 'geofences', 'alerts', 'trips', 'admin', 'settings'],
+  child_user: ['dashboard', 'map', 'vehicles', 'drivers', 'geofences', 'alerts', 'trips', 'settings'],
+};
 
 function App() {
   const [activeView, setActiveView] = useState('dashboard');
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [alerts, setAlerts] = useState<Alert[]>(mockAlerts);
+  const [authUsers, setAuthUsers] = useState<AuthUser[]>(mockAuthUsers);
+  const [currentUser, setCurrentUser] = useState<SessionUser | null>(null);
+  const [loginError, setLoginError] = useState<string | null>(null);
 
   // Simulate real-time updates
   useEffect(() => {
@@ -31,42 +43,84 @@ function App() {
       // In a real implementation, this would be WebSocket connections
       console.log('Real-time data update simulation');
     }, 10000);
-    
+
     return () => clearInterval(interval);
   }, []);
 
-  const currentUser = {
-    name: 'Carlos Mendes',
-    email: 'carlos.mendes@empresa.com',
-    role: 'manager'
+  useEffect(() => {
+    if (!currentUser) {
+      return;
+    }
+
+    const allowedViews = viewPermissions[currentUser.role];
+    if (!allowedViews.includes(activeView)) {
+      setActiveView(allowedViews[0]);
+    }
+  }, [currentUser, activeView]);
+
+  const pendingAlerts = useMemo(
+    () => alerts.filter(alert => !alert.acknowledged).length,
+    [alerts],
+  );
+
+  const handleLogin = ({ email, password }: LoginCredentials) => {
+    const normalizedEmail = email.trim().toLowerCase();
+    const matchingUser = authUsers.find(
+      user => user.email.toLowerCase() === normalizedEmail && user.password === password,
+    );
+
+    if (!matchingUser) {
+      setLoginError('E-mail ou senha inválidos. Verifique as credenciais e tente novamente.');
+      return;
+    }
+
+    const { password: _password, ...sessionUser } = matchingUser;
+    setCurrentUser(sessionUser);
+    setLoginError(null);
   };
 
-  const pendingAlerts = alerts.filter(a => !a.acknowledged).length;
+  const handleLogout = () => {
+    setCurrentUser(null);
+    setActiveView('dashboard');
+    setIsCollapsed(false);
+  };
 
   const handleAcknowledgeAlert = (alertId: string) => {
-    setAlerts(prev => prev.map(alert => 
-      alert.id === alertId 
-        ? { 
-            ...alert, 
-            acknowledged: true, 
-            acknowledgedBy: currentUser.name,
-            acknowledgedAt: new Date().toISOString()
-          }
-        : alert
-    ));
+    setAlerts(prev =>
+      prev.map(alert =>
+        alert.id === alertId
+          ? {
+              ...alert,
+              acknowledged: true,
+              acknowledgedBy: currentUser?.name ?? 'Usuário',
+              acknowledgedAt: new Date().toISOString(),
+            }
+          : alert,
+      ),
+    );
   };
 
   const renderView = () => {
+    if (!currentUser) {
+      return null;
+    }
+
     switch (activeView) {
       case 'dashboard':
         return <DashboardView devices={mockDevices} alerts={alerts} vehicles={mockVehicles} />;
       case 'map':
-        return <FleetMapView 
-          devices={mockDevices} 
-          drivers={mockDrivers} 
-          vehicles={mockVehicles}
-          onNavigateToAdmin={() => setActiveView('admin')}
-        />;
+        return (
+          <FleetMapView
+            devices={mockDevices}
+            drivers={mockDrivers}
+            vehicles={mockVehicles}
+            onNavigateToAdmin={() => {
+              if (viewPermissions[currentUser.role].includes('admin')) {
+                setActiveView('admin');
+              }
+            }}
+          />
+        );
       case 'vehicles':
         return <VehiclesList devices={mockDevices} vehicles={mockVehicles} drivers={mockDrivers} />;
       case 'drivers':
@@ -78,29 +132,51 @@ function App() {
       case 'trips':
         return <TripsView trips={mockTrips} drivers={mockDrivers} vehicles={mockVehicles} />;
       case 'admin':
-        return <AdminView />;
+        if (currentUser.role === 'child_user') {
+          return (
+            <div className="bg-white border border-red-200 text-red-700 rounded-xl p-6">
+              <h2 className="text-lg font-semibold mb-2">Acesso restrito</h2>
+              <p className="text-sm">
+                Apenas o admin geral e usuários mestres podem acessar a área administrativa completa.
+              </p>
+            </div>
+          );
+        }
+
+        return (
+          <AdminView
+            currentUser={currentUser}
+            users={authUsers}
+            onUsersChange={setAuthUsers}
+          />
+        );
       case 'settings':
         return <SettingsView />;
       default:
-        return <DashboardView devices={mockDevices} alerts={alerts} />;
+        return <DashboardView devices={mockDevices} alerts={alerts} vehicles={mockVehicles} />;
     }
   };
 
+  if (!currentUser) {
+    return <LoginView onLogin={handleLogin} error={loginError} users={authUsers} />;
+  }
+
+  const allowedViews = viewPermissions[currentUser.role];
+
   return (
     <div className="flex flex-col lg:flex-row min-h-screen bg-gray-50">
-      <Sidebar 
+      <Sidebar
         activeView={activeView}
         onViewChange={setActiveView}
         isCollapsed={isCollapsed}
         onToggleCollapse={() => setIsCollapsed(!isCollapsed)}
+        allowedViews={allowedViews}
       />
-      
+
       <div className="flex-1 flex flex-col min-w-0">
-        <Header user={currentUser} alertCount={pendingAlerts} />
-        
-        <main className="flex-1 p-3 sm:p-6 overflow-auto">
-          {renderView()}
-        </main>
+        <Header user={currentUser} alertCount={pendingAlerts} onLogout={handleLogout} />
+
+        <main className="flex-1 p-3 sm:p-6 overflow-auto">{renderView()}</main>
       </div>
     </div>
   );

--- a/src/components/Admin/AdminView.tsx
+++ b/src/components/Admin/AdminView.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
-import { 
-  Building, 
-  Truck, 
-  Smartphone, 
-  Users, 
-  Shield, 
+import {
+  Building,
+  Truck,
+  Smartphone,
+  Users,
+  Shield,
   BarChart3,
-  Settings as SettingsIcon
+  Settings as SettingsIcon,
+  UserPlus
 } from 'lucide-react';
 import { ClientsManagement } from './ClientsManagement';
 import { VehiclesManagement } from './VehiclesManagement';
@@ -16,12 +17,21 @@ import { RolesManagement } from './RolesManagement';
 import { AdminReports } from './AdminReports';
 import { EquipmentRegistration } from '../Equipment/EquipmentRegistration';
 import { AdminSettings } from './AdminSettings';
+import { UserHierarchyManager } from './UserHierarchyManager';
+import { AuthUser, SessionUser } from '../../types/auth';
 
-export const AdminView: React.FC = () => {
+interface AdminViewProps {
+  currentUser: SessionUser;
+  users: AuthUser[];
+  onUsersChange: (users: AuthUser[]) => void;
+}
+
+export const AdminView: React.FC<AdminViewProps> = ({ currentUser, users, onUsersChange }) => {
   const [activeTab, setActiveTab] = useState('clients');
 
   const tabs = [
     { id: 'clients', label: 'Clientes', icon: Building },
+    { id: 'userHierarchy', label: 'Usuários & Hierarquia', icon: UserPlus },
     { id: 'equipment', label: 'Equipamentos', icon: Smartphone },
     { id: 'vehicles', label: 'Veículos', icon: Truck },
     { id: 'devices', label: 'Dispositivos', icon: Smartphone },
@@ -35,6 +45,14 @@ export const AdminView: React.FC = () => {
     switch (activeTab) {
       case 'clients':
         return <ClientsManagement />;
+      case 'userHierarchy':
+        return (
+          <UserHierarchyManager
+            currentUser={currentUser}
+            users={users}
+            onUsersChange={onUsersChange}
+          />
+        );
       case 'equipment':
         return <EquipmentRegistration />;
       case 'vehicles':

--- a/src/components/Admin/UserHierarchyManager.tsx
+++ b/src/components/Admin/UserHierarchyManager.tsx
@@ -1,0 +1,413 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { AuthRole, AuthUser, SessionUser } from '../../types/auth';
+import { KeyRound, Shield, UserPlus, Users } from 'lucide-react';
+
+interface UserHierarchyManagerProps {
+  currentUser: SessionUser;
+  users: AuthUser[];
+  onUsersChange: (nextUsers: AuthUser[]) => void;
+}
+
+const roleLabels: Record<AuthRole, string> = {
+  super_admin: 'Admin geral',
+  master_admin: 'Usuário mestre',
+  child_user: 'Usuário filho',
+};
+
+const creationRules: Record<AuthRole, AuthRole[]> = {
+  super_admin: ['master_admin', 'child_user'],
+  master_admin: ['child_user'],
+  child_user: [],
+};
+
+interface FormState {
+  name: string;
+  email: string;
+  password: string;
+  role: AuthRole;
+  parentId?: string;
+}
+
+export const UserHierarchyManager: React.FC<UserHierarchyManagerProps> = ({
+  currentUser,
+  users,
+  onUsersChange,
+}) => {
+  const availableRoles = creationRules[currentUser.role];
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const masters = useMemo(() => users.filter(user => user.role === 'master_admin'), [users]);
+  const superAdmins = useMemo(() => users.filter(user => user.role === 'super_admin'), [users]);
+  const childrenByParent = useMemo(() => {
+    return users
+      .filter(user => user.role === 'child_user')
+      .reduce<Record<string, AuthUser[]>>((accumulator, user) => {
+        if (!user.parentId) {
+          return accumulator;
+        }
+        if (!accumulator[user.parentId]) {
+          accumulator[user.parentId] = [];
+        }
+        accumulator[user.parentId].push(user);
+        return accumulator;
+      }, {});
+  }, [users]);
+
+  const defaultRole = availableRoles[0] ?? 'child_user';
+  const defaultParentId =
+    currentUser.role === 'master_admin'
+      ? currentUser.id
+      : currentUser.role === 'super_admin' && masters.length > 0
+        ? masters[0].id
+        : undefined;
+
+  const [formState, setFormState] = useState<FormState>({
+    name: '',
+    email: '',
+    password: '',
+    role: defaultRole,
+    parentId: defaultParentId,
+  });
+
+  useEffect(() => {
+    setFormState({
+      name: '',
+      email: '',
+      password: '',
+      role: defaultRole,
+      parentId: defaultParentId,
+    });
+    setFeedback(null);
+  }, [defaultRole, defaultParentId, currentUser.id]);
+
+  const resetForm = (nextRole?: AuthRole) => {
+    const derivedRole = nextRole ?? availableRoles[0] ?? 'child_user';
+    setFormState({
+      name: '',
+      email: '',
+      password: '',
+      role: derivedRole,
+      parentId:
+        currentUser.role === 'master_admin'
+          ? currentUser.id
+          : currentUser.role === 'super_admin' && masters.length > 0
+            ? masters[0].id
+            : undefined,
+    });
+  };
+
+  const handleInputChange = (field: keyof FormState) => (
+    event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const value = event.target.value;
+    setFormState(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleRoleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value as AuthRole;
+    setFormState(prev => ({
+      ...prev,
+      role: value,
+      parentId: value === 'child_user'
+        ? currentUser.role === 'master_admin'
+          ? currentUser.id
+          : masters[0]?.id ?? prev.parentId ?? ''
+        : currentUser.id,
+    }));
+  };
+
+  const emailExists = (email: string) =>
+    users.some(user => user.email.toLowerCase() === email.toLowerCase());
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (availableRoles.length === 0) {
+      setFeedback({ type: 'error', message: 'Você não possui permissão para criar novos usuários.' });
+      return;
+    }
+
+    const { name, email, password, role } = formState;
+    if (!name || !email || !password) {
+      setFeedback({ type: 'error', message: 'Preencha todos os campos para criar o usuário.' });
+      return;
+    }
+
+    if (emailExists(email)) {
+      setFeedback({ type: 'error', message: 'Já existe um usuário com este e-mail cadastrado.' });
+      return;
+    }
+
+    let parentId = formState.parentId;
+
+    if (role === 'master_admin') {
+      parentId = currentUser.id;
+    }
+
+    if (role === 'child_user') {
+      if (currentUser.role === 'master_admin') {
+        parentId = currentUser.id;
+      }
+
+      if (!parentId) {
+        setFeedback({ type: 'error', message: 'Selecione o usuário mestre responsável por este usuário filho.' });
+        return;
+      }
+    }
+
+    const newUser: AuthUser = {
+      id: `user-${Date.now()}`,
+      name,
+      email,
+      password,
+      role,
+      parentId,
+    };
+
+    onUsersChange([...users, newUser]);
+    setFeedback({ type: 'success', message: `${roleLabels[role]} criado com sucesso.` });
+    resetForm(role);
+  };
+
+  const renderChildren = (parentId: string) => {
+    const children = childrenByParent[parentId] ?? [];
+    if (children.length === 0) {
+      return (
+        <p className="text-sm text-gray-400">Nenhum usuário filho vinculado.</p>
+      );
+    }
+
+    return (
+      <ul className="space-y-2">
+        {children.map(child => (
+          <li
+            key={child.id}
+            className="flex items-center justify-between bg-slate-800/40 border border-slate-700 rounded-xl px-3 py-2"
+          >
+            <div>
+              <p className="text-sm font-medium text-white">{child.name}</p>
+              <p className="text-xs text-slate-300">{child.email}</p>
+            </div>
+            <span className="text-xs text-blue-300 capitalize">{roleLabels[child.role]}</span>
+          </li>
+        ))}
+      </ul>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white rounded-xl border border-gray-200 p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900">Hierarquia de usuários</h2>
+            <p className="text-sm text-gray-600">
+              Controle quem pode criar novos acessos de acordo com o nível atual do usuário logado.
+            </p>
+          </div>
+          <div className="flex items-center gap-3 bg-blue-50 border border-blue-100 text-blue-700 px-4 py-2 rounded-lg text-sm">
+            <Shield size={18} />
+            <span>
+              Você está logado como <strong>{roleLabels[currentUser.role]}</strong>
+            </span>
+          </div>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-4 text-sm">
+          <div className="p-4 rounded-xl border border-gray-200 bg-gray-50">
+            <h3 className="font-semibold text-gray-900 mb-2">Admin geral</h3>
+            <p className="text-gray-600">Pode criar usuários mestres e filhos para qualquer operação.</p>
+          </div>
+          <div className="p-4 rounded-xl border border-gray-200 bg-gray-50">
+            <h3 className="font-semibold text-gray-900 mb-2">Usuário mestre</h3>
+            <p className="text-gray-600">Pode criar e gerenciar apenas usuários filhos da sua operação.</p>
+          </div>
+          <div className="p-4 rounded-xl border border-gray-200 bg-gray-50">
+            <h3 className="font-semibold text-gray-900 mb-2">Usuário filho</h3>
+            <p className="text-gray-600">Não possui permissão para criar novos acessos.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid lg:grid-cols-2 gap-6">
+        <div className="bg-white rounded-xl border border-gray-200 p-6">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 bg-blue-100 rounded-lg text-blue-600">
+              <UserPlus size={18} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900">Criar novo usuário</h3>
+              <p className="text-sm text-gray-600">Disponível conforme o nível de permissão atual.</p>
+            </div>
+          </div>
+
+          {availableRoles.length === 0 ? (
+            <div className="bg-gray-50 border border-gray-200 text-gray-600 text-sm rounded-xl px-4 py-3">
+              Usuários filhos não podem criar novos acessos. Entre como usuário mestre ou admin geral para cadastrar mais contas.
+            </div>
+          ) : (
+            <form className="space-y-4" onSubmit={handleSubmit}>
+              <div className="grid sm:grid-cols-2 gap-4">
+                <div className="space-y-1">
+                  <label className="text-sm font-medium text-gray-700">Nome completo</label>
+                  <input
+                    type="text"
+                    value={formState.name}
+                    onChange={handleInputChange('name')}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="Nome do usuário"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium text-gray-700">E-mail corporativo</label>
+                  <input
+                    type="email"
+                    value={formState.email}
+                    onChange={handleInputChange('email')}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="usuario@empresa.com"
+                  />
+                </div>
+              </div>
+
+              <div className="grid sm:grid-cols-2 gap-4">
+                <div className="space-y-1">
+                  <label className="text-sm font-medium text-gray-700">Senha temporária</label>
+                  <div className="relative">
+                    <KeyRound className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={16} />
+                    <input
+                      type="text"
+                      value={formState.password}
+                      onChange={handleInputChange('password')}
+                      className="w-full border border-gray-300 rounded-lg pl-9 pr-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      placeholder="Defina uma senha inicial"
+                    />
+                  </div>
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium text-gray-700">Nível de acesso</label>
+                  <select
+                    value={formState.role}
+                    onChange={handleRoleChange}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  >
+                    {availableRoles.map(role => (
+                      <option key={role} value={role}>
+                        {roleLabels[role]}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              {formState.role === 'child_user' && currentUser.role === 'super_admin' && (
+                <div className="space-y-1">
+                  <label className="text-sm font-medium text-gray-700">Usuário mestre responsável</label>
+                  <select
+                    value={formState.parentId ?? ''}
+                    onChange={handleInputChange('parentId')}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  >
+                    <option value="">Selecione um usuário mestre</option>
+                    {masters.map(master => (
+                      <option key={master.id} value={master.id}>
+                        {master.name} ({master.email})
+                      </option>
+                    ))}
+                  </select>
+                  {masters.length === 0 && (
+                    <p className="text-xs text-red-500">Cadastre um usuário mestre antes de criar usuários filhos.</p>
+                  )}
+                </div>
+              )}
+
+              {feedback && (
+                <div
+                  className={`rounded-lg px-4 py-3 text-sm border ${
+                    feedback.type === 'success'
+                      ? 'bg-green-50 text-green-700 border-green-200'
+                      : 'bg-red-50 text-red-600 border-red-200'
+                  }`}
+                >
+                  {feedback.message}
+                </div>
+              )}
+
+              <button
+                type="submit"
+                className="w-full bg-blue-600 text-white rounded-lg py-2.5 font-semibold hover:bg-blue-700 transition-colors"
+              >
+                Criar usuário
+              </button>
+            </form>
+          )}
+        </div>
+
+        <div className="bg-slate-900 text-white rounded-xl border border-slate-800 p-6 space-y-4">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-slate-800 rounded-lg">
+              <Users size={18} />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold">Usuários cadastrados</h3>
+              <p className="text-sm text-slate-300">Visualize a hierarquia atual de admins, mestres e filhos.</p>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            {superAdmins.map(admin => (
+              <div key={admin.id} className="bg-white/5 rounded-xl border border-white/10 p-4 space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold">{admin.name}</p>
+                    <p className="text-xs text-slate-300">{admin.email}</p>
+                  </div>
+                  <span className="text-xs bg-blue-500/20 border border-blue-400/30 px-2 py-1 rounded-full">
+                    {roleLabels[admin.role]}
+                  </span>
+                </div>
+
+                {masters
+                  .filter(master => master.parentId === admin.id)
+                  .map(master => (
+                    <div key={master.id} className="bg-slate-800/60 border border-slate-700 rounded-xl p-3 space-y-3">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-sm font-semibold text-white">{master.name}</p>
+                          <p className="text-xs text-slate-300">{master.email}</p>
+                        </div>
+                        <span className="text-xs bg-purple-500/20 border border-purple-400/30 px-2 py-1 rounded-full">
+                          {roleLabels[master.role]}
+                        </span>
+                      </div>
+
+                      <div className="pl-3 border-l border-slate-700 space-y-2">
+                        {renderChildren(master.id)}
+                      </div>
+                    </div>
+                  ))}
+              </div>
+            ))}
+
+            {masters.filter(master => !master.parentId).length > 0 && (
+              <div className="bg-white/5 rounded-xl border border-amber-400/40 p-4 space-y-3">
+                <p className="text-sm font-semibold text-amber-200">
+                  Usuários mestres sem vínculo com um admin geral
+                </p>
+                <ul className="space-y-2 text-sm text-slate-200">
+                  {masters
+                    .filter(master => !master.parentId)
+                    .map(master => (
+                      <li key={master.id} className="flex items-center justify-between">
+                        <span>{master.name}</span>
+                        <span className="text-xs text-slate-400">{master.email}</span>
+                      </li>
+                    ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Auth/LoginView.tsx
+++ b/src/components/Auth/LoginView.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react';
+import { Lock, Mail, LogIn, Shield, Users } from 'lucide-react';
+import { AuthUser, LoginCredentials } from '../../types/auth';
+
+interface LoginViewProps {
+  onLogin: (credentials: LoginCredentials) => void;
+  error?: string | null;
+  users?: AuthUser[];
+}
+
+export const LoginView: React.FC<LoginViewProps> = ({ onLogin, error, users }) => {
+  const [credentials, setCredentials] = useState<LoginCredentials>({
+    email: '',
+    password: '',
+  });
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onLogin(credentials);
+  };
+
+  const handleChange = (field: keyof LoginCredentials) => (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setCredentials(prev => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const demoAccounts = users ?? [];
+
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center px-4 py-12">
+      <div className="w-full max-w-4xl grid lg:grid-cols-2 gap-8">
+        <div className="bg-white/10 backdrop-blur rounded-3xl p-6 sm:p-10 text-white border border-white/10">
+          <div className="flex items-center gap-3 mb-8">
+            <div className="p-3 bg-blue-500/20 rounded-2xl border border-blue-500/40">
+              <Shield className="text-blue-300" size={28} />
+            </div>
+            <div>
+              <h1 className="text-2xl sm:text-3xl font-bold">Linka Fleet</h1>
+              <p className="text-sm text-white/70">Console seguro para gestão de frotas</p>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div>
+              <h2 className="text-lg font-semibold mb-2">Hierarquia de acesso</h2>
+              <p className="text-sm text-white/70">
+                Admin geral controla usuários mestres, que por sua vez criam e gerem usuários filhos restritos. Utilize o login
+                adequado para testar os diferentes níveis de permissão.
+              </p>
+            </div>
+
+            {demoAccounts.length > 0 && (
+              <div className="bg-white/5 rounded-2xl border border-white/10 p-4 space-y-3">
+                <div className="flex items-center gap-2 text-sm font-semibold text-white/80">
+                  <Users size={16} />
+                  Contas de demonstração
+                </div>
+                <ul className="space-y-2 text-xs sm:text-sm text-white/70">
+                  {demoAccounts.map(account => (
+                    <li
+                      key={account.id}
+                      className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-4"
+                    >
+                      <span className="font-medium text-white">{account.email}</span>
+                      <span className="capitalize text-blue-200">
+                        {account.role.replace('_', ' ')}
+                      </span>
+                      <span className="font-mono text-white/60">Senha: {account.password}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="bg-white rounded-3xl shadow-2xl p-6 sm:p-10">
+          <div className="space-y-2 mb-8">
+            <h2 className="text-2xl sm:text-3xl font-bold text-gray-900">Acesse sua conta</h2>
+            <p className="text-gray-500">Entre com seu e-mail corporativo para continuar</p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="space-y-2">
+              <label htmlFor="email" className="text-sm font-medium text-gray-700">
+                E-mail
+              </label>
+              <div className="relative">
+                <Mail className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+                <input
+                  id="email"
+                  type="email"
+                  value={credentials.email}
+                  onChange={handleChange('email')}
+                  placeholder="seu.email@empresa.com"
+                  className="w-full pl-12 pr-4 py-3 border border-gray-200 rounded-2xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="password" className="text-sm font-medium text-gray-700">
+                Senha
+              </label>
+              <div className="relative">
+                <Lock className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+                <input
+                  id="password"
+                  type="password"
+                  value={credentials.password}
+                  onChange={handleChange('password')}
+                  placeholder="********"
+                  className="w-full pl-12 pr-4 py-3 border border-gray-200 rounded-2xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  required
+                />
+              </div>
+            </div>
+
+            {error && (
+              <div className="bg-red-50 border border-red-200 text-red-600 text-sm rounded-2xl px-4 py-3">
+                {error}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              className="w-full flex items-center justify-center gap-2 bg-blue-600 text-white py-3 rounded-2xl font-semibold hover:bg-blue-700 transition-colors"
+            >
+              <LogIn size={18} />
+              Entrar
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,16 +1,22 @@
 import React from 'react';
 import { Bell, Search, User, LogOut } from 'lucide-react';
+import { SessionUser } from '../../types/auth';
 
 interface HeaderProps {
-  user: {
-    name: string;
-    email: string;
-    role: string;
-  };
+  user: SessionUser;
   alertCount: number;
+  onLogout: () => void;
 }
 
-export const Header: React.FC<HeaderProps> = ({ user, alertCount }) => {
+const roleLabels: Record<SessionUser['role'], string> = {
+  super_admin: 'Admin geral',
+  master_admin: 'Usuário mestre',
+  child_user: 'Usuário filho',
+};
+
+export const Header: React.FC<HeaderProps> = ({ user, alertCount, onLogout }) => {
+  const roleLabel = roleLabels[user.role] ?? user.role;
+
   return (
     <header className="bg-white border-b border-gray-200 px-3 sm:px-6 py-3 sm:py-4">
       <div className="flex items-center justify-between">
@@ -38,14 +44,17 @@ export const Header: React.FC<HeaderProps> = ({ user, alertCount }) => {
           <div className="flex items-center gap-2 sm:gap-3 pl-2 sm:pl-4 border-l border-gray-200">
             <div className="text-right hidden sm:block">
               <div className="text-sm font-medium text-gray-900">{user.name}</div>
-              <div className="text-xs text-gray-500 capitalize">{user.role}</div>
+              <div className="text-xs text-gray-500 capitalize">{roleLabel}</div>
             </div>
             <div className="relative">
               <button className="flex items-center gap-2 p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">
                 <User size={18} />
               </button>
             </div>
-            <button className="p-2 text-gray-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors">
+            <button
+              onClick={onLogout}
+              className="p-2 text-gray-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+            >
               <LogOut size={18} />
             </button>
           </div>

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -17,13 +17,15 @@ interface SidebarProps {
   onViewChange: (view: string) => void;
   isCollapsed: boolean;
   onToggleCollapse: () => void;
+  allowedViews?: string[];
 }
 
-export const Sidebar: React.FC<SidebarProps> = ({ 
-  activeView, 
-  onViewChange, 
-  isCollapsed, 
-  onToggleCollapse 
+export const Sidebar: React.FC<SidebarProps> = ({
+  activeView,
+  onViewChange,
+  isCollapsed,
+  onToggleCollapse,
+  allowedViews
 }) => {
   const menuItems = [
     { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
@@ -36,6 +38,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
     { id: 'admin', label: 'Administração', icon: Shield },
     { id: 'settings', label: 'Configurações', icon: Settings },
   ];
+
+  const itemsToShow = allowedViews
+    ? menuItems.filter(item => allowedViews.includes(item.id))
+    : menuItems;
 
   return (
     <aside className={`bg-slate-900 text-white transition-all duration-300 ${
@@ -59,10 +65,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
       
       <nav className="flex-1 p-4">
         <ul className="space-y-1 sm:space-y-2">
-          {menuItems.map((item) => {
+          {itemsToShow.map((item) => {
             const Icon = item.icon;
             const isActive = activeView === item.id;
-            
+
             return (
               <li key={item.id}>
                 <button

--- a/src/data/authUsers.ts
+++ b/src/data/authUsers.ts
@@ -1,0 +1,27 @@
+import { AuthUser } from '../types/auth';
+
+export const mockAuthUsers: AuthUser[] = [
+  {
+    id: 'user-1',
+    name: 'Ana Souza',
+    email: 'ana.souza@linka.com',
+    role: 'super_admin',
+    password: 'admin123',
+  },
+  {
+    id: 'user-2',
+    name: 'Bruno Lima',
+    email: 'bruno.lima@empresa.com',
+    role: 'master_admin',
+    password: 'master123',
+    parentId: 'user-1',
+  },
+  {
+    id: 'user-3',
+    name: 'Carla Ribeiro',
+    email: 'carla.ribeiro@empresa.com',
+    role: 'child_user',
+    password: 'user123',
+    parentId: 'user-2',
+  },
+];

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,17 @@
+export type AuthRole = 'super_admin' | 'master_admin' | 'child_user';
+
+export interface AuthUser {
+  id: string;
+  name: string;
+  email: string;
+  role: AuthRole;
+  password: string;
+  parentId?: string;
+}
+
+export type SessionUser = Omit<AuthUser, 'password'>;
+
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}


### PR DESCRIPTION
## Summary
- add a dedicated login screen tied to mock authentication users and track the active session
- gate sidebar navigation, admin access, and alert acknowledgements by role permissions with logout support
- introduce user hierarchy management inside Admin, allowing super admins to create masters and masters to create child users

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e316c75d208330abfc88c46f598b8d